### PR TITLE
feat(gh): allow latest arg to be an enum

### DIFF
--- a/gh/release.go
+++ b/gh/release.go
@@ -16,6 +16,14 @@ type Release struct {
 	Gh *Gh
 }
 
+type Latest string
+
+const (
+	LatestTrue  Latest = "true"
+	LatestFalse Latest = "false"
+	LatestAuto  Latest = "auto"
+)
+
 // Create a new GitHub Release for a repository.
 func (m *Release) Create(
 	ctx context.Context,
@@ -74,7 +82,8 @@ func (m *Release) Create(
 	// Mark this release as "Latest" (default: automatic based on date and version).
 	//
 	// +optional
-	latest bool,
+	// +default="auto"
+	latest Latest,
 
 	// Abort in case the git tag doesn't already exist in the remote repository.
 	//
@@ -137,8 +146,13 @@ func (m *Release) Create(
 		args = append(args, "--notes-start-tag", notesStartTag)
 	}
 
-	if latest {
-		args = append(args, "--latest")
+	switch latest {
+	case LatestAuto:
+		// automatic based on date and version
+	case LatestTrue:
+		args = append(args, "--latest=true")
+	case LatestFalse:
+		args = append(args, "--latest=false")
 	}
 
 	if verifyTag {


### PR DESCRIPTION
The possible values for `latest` are a trinary: "true", "false", and a magic auto value that happens when the arg isn't specified:

> --latest
>        Mark this release as "Latest" (default [automatic based on date and version]).
>        --latest=false to explicitly NOT set as latest

Today the value is only a boolean, and so there's no way at the moment to force latest to be false. By updating the arg type to a trinary enum, then we can express this constraint properly.